### PR TITLE
use config warning handler if it exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,8 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
         build: {
           rollupOptions: {
             onwarn: (warning, rollupWarn) => {
-              handleCircularDependancyWarning(warning, rollupWarn)
+              const warningHandler = _config.build?.rollupOptions?.onwarn ?? rollupWarn
+              handleCircularDependancyWarning(warning, warningHandler)
             },
             plugins: [
               {


### PR DESCRIPTION
plugin should use the existing configured warning handler if there is one.

for example using [react-query causes many MODULE_LEVEL_DIRECTIVE warnings](https://github.com/TanStack/query/issues/5175) which are now suppressed by @vitejs/plugin-react. However, when also using the current version of this plugin, that suppression no longer works as it reverts to the default handler. This PR is based on the [onwarn handler in the react plugin](https://github.com/vitejs/vite-plugin-react/blob/5503e39489cd41a6937fe86fe61f9b1ac7b99620/packages/plugin-react/src/index.ts#L310C37-L310C37).