### PR TITLE
Slim down published package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
       "import": "./shims/banner/dist/index.cjs"
     }
   },
+  "files": [
+    "dist",
+    "shims"
+  ],
   "scripts": {
     "build": "run-s build:core build:shims build:shims:banner build:types",
     "build:core": "vite build",


### PR DESCRIPTION
The published version of this package is over 13 MB, which seems a bit excessive. It's more or less all `examples/` which I think we could avoid shipping?

As far as I can tell it's enough to include `dist` and `shims`, leaving `examples`, `patches`, and `pnpm-workspace.yaml` out of the published package.

I have not tested this in any way 😁 