### PR TITLE
Fix usage of rollupOptions.onWarn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,10 +199,7 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
         build: {
           rollupOptions: {
             onwarn: (warning, rollupWarn) => {
-              handleCircularDependancyWarning(warning, rollupWarn)
-
-              // Make sure the predefined `onwarn` handler is called too.
-              config.build?.rollupOptions?.onwarn?.(warning, rollupWarn)
+              handleCircularDependancyWarning(warning, config.build?.rollupOptions?.onwarn ?? rollupWarn)
             },
             plugins: [
               {


### PR DESCRIPTION
Otherwise plugins like the reacts one can't hide the `use-client` directive warning.

The callback will then be called by the util: https://github.com/niksy/node-stdlib-browser/blob/master/helpers/rollup/plugin.js#L29

This probably also avoid double print of other warnings.