### PR TITLE
define globalThis if not defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ const globalShimsBanner = [
   `import __global_polyfill from 'vite-plugin-node-polyfills/shims/global'`,
   `import __process_polyfill from 'vite-plugin-node-polyfills/shims/process'`,
   ``,
+  `globalThis = globalThis ?? window`,
   `globalThis.Buffer = globalThis.Buffer || __buffer_polyfill`,
   `globalThis.global = globalThis.global || __global_polyfill`,
   `globalThis.process = globalThis.process || __process_polyfill`,


### PR DESCRIPTION
I'm using this plugin in a project that started throwing errors in some sub-dependency because `globalThis` wasn't defined yet when this code ran. This one-line change resolves those errors. :-)