### PR TITLE
Perf issue fix: avoid creating an inject plugin when there are no shims to inject

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,13 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
     config: (config, env) => {
       const isDev = env.command === 'serve'
 
+      const shimsToInject = {
+        // https://github.com/niksy/node-stdlib-browser/blob/3e7cd7f3d115ac5c4593b550e7d8c4a82a0d4ac4/README.md#vite
+        ...(isEnabled(optionsResolved.globals.Buffer, 'build') ? { Buffer: 'vite-plugin-node-polyfills/shims/buffer' } : {}),
+        ...(isEnabled(optionsResolved.globals.global, 'build') ? { global: 'vite-plugin-node-polyfills/shims/global' } : {}),
+        ...(isEnabled(optionsResolved.globals.process, 'build') ? { process: 'vite-plugin-node-polyfills/shims/process' } : {}),
+      }
+
       return {
         build: {
           rollupOptions: {
@@ -216,16 +223,7 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
                 rollupWarn(warning)
               })
             },
-            plugins: [
-              {
-                ...inject({
-                  // https://github.com/niksy/node-stdlib-browser/blob/3e7cd7f3d115ac5c4593b550e7d8c4a82a0d4ac4/README.md#vite
-                  ...(isEnabled(optionsResolved.globals.Buffer, 'build') ? { Buffer: 'vite-plugin-node-polyfills/shims/buffer' } : {}),
-                  ...(isEnabled(optionsResolved.globals.global, 'build') ? { global: 'vite-plugin-node-polyfills/shims/global' } : {}),
-                  ...(isEnabled(optionsResolved.globals.process, 'build') ? { process: 'vite-plugin-node-polyfills/shims/process' } : {}),
-                }),
-              },
-            ],
+            plugins: Object.keys(shimsToInject).length > 0 ? [inject(shimsToInject)] : [],
           },
         },
         esbuild: {


### PR DESCRIPTION
I started using `vite-plugin-node-polyfills` on a fairly large vite project and it made `vite build` slower by 50-100%. It also caused increased memory usage (causing OOM errors).

I tracked down the source of the slowdown to the `inject` plugin. My config had `globals.{Buffer, global, process}` all set to `false` so the plugin was not necessary.

I reworked the logic to avoid passing in the inject plugin when there are no shims to inject.