### PR TITLE
Add support for Vite v6

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -3,25 +3,17 @@ description: Install and cache dependencies
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - uses: pnpm/action-setup@v2.4.0
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
       with:
         run_install: false
-        version: 8
-    - name: Get the pnpm store directory
-      shell: bash
-      run: |
-        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-    - name: Setup the pnpm cache
-      uses: actions/cache@v3
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
       with:
-        key: v1-${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-        path: |
-          ${{ env.STORE_PATH }}
-        restore-keys: v1-${{ runner.os }}-pnpm-store-
+        node-version: 18
+        cache: pnpm
     - name: Install dependencies
       shell: bash
       run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,47 +5,34 @@ on:
     branches:
       - main
 jobs:
-  install-dependencies:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/install-dependencies
   lint:
-    needs:
-      - install-dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - name: Run the linter
         run: pnpm lint
   test-e2e:
-    needs:
-      - install-dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - run: pnpm build:core
       - run: pnpm build:shims
       - run: pnpm playwright install --with-deps
       - run: pnpm -r test:e2e
   test-unit:
-    needs:
-      - install-dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - run: pnpm build:core
       - run: pnpm build:shims
       - run: pnpm -r test
   typecheck:
-    needs:
-      - install-dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/install-dependencies
       - run: pnpm build:core
       - run: pnpm build:shims

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typecheck:vue": "pnpm -C ./examples/vue run typecheck"
   },
   "peerDependencies": {
-    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "@rollup/plugin-inject": "^5.0.5",


### PR DESCRIPTION
Since the workaround in the issue https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/110 comment seems to work okay, this should do the trick.

Didn't bump the package version since you may want to update dependencies further before releasing it? :)

Fixes #110
Fixes #113 

### Note: If you're taking a look because this issue happened to you, I've published a fork of this repo as [vite-plugin-node-polyfill](https://www.npmjs.com/package/vite-plugin-node-polyfill) with Vite v6 support 😄 