### PR TITLE
Add rolldown-vite 7.2.3+ support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm playwright install --with-deps
       - name: update overrides to use rolldown-vite and re-install
         run: |
-          jq '.pnpm.overrides.vite = "npm:rolldown-vite@^7.0.1"' package.json > package.tmp.json
+          jq '.pnpm.overrides.vite = "npm:rolldown-vite@^7.2.5"' package.json > package.tmp.json
           mv package.tmp.json package.json
           pnpm i --no-frozen-lockfile
       - run: pnpm -r test:e2e

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,7 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
             },
             ...Object.keys(shimsToInject).length > 0
               ? isRolldownVite
-                ? { inject: shimsToInject }
+                ? { transform: { inject: shimsToInject } }
                 : { plugins: [inject(shimsToInject)] }
               : {},
           },
@@ -249,13 +249,15 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
           ],
           ...isRolldownVite
             ? {
-                rollupOptions: {
-                  define: defines,
+                rolldownOptions: {
                   resolve: {
                     // https://github.com/niksy/node-stdlib-browser/blob/3e7cd7f3d115ac5c4593b550e7d8c4a82a0d4ac4/README.md?plain=1#L150
                     alias: {
                       ...polyfills,
                     },
+                  },
+                  transform: {
+                    define: defines,
                   },
                   plugins: [
                     {


### PR DESCRIPTION
rolldown-vite 7.2.3 has a breaking change (https://github.com/rolldown/rolldown/releases/tag/v1.0.0-beta.48) and this PR changes the code for it.
This PR also changes the deprecated `optimizeDeps.rollupOptions` to `optimizeDeps.rolldownOptions`.

The new options are only supported by rolldown-vite 7.1.19+, so users using the older version would have to upgrade rolldown-vite together.