### PR TITLE
Run CI against Vite 8 beta instead of rolldown-vite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: pnpm build:core
       - run: pnpm build:shims
       - run: pnpm playwright install --with-deps
-      - name: update overrides to use rolldown-vite and re-install
+      - name: update overrides to use vite 8 beta and re-install
         run: |
           jq '.pnpm.overrides.vite = "8.0.0-beta.7"' package.json > package.tmp.json
           mv package.tmp.json package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - run: pnpm build:shims
       - run: pnpm playwright install --with-deps
       - run: pnpm -r test:e2e
-  test-e2e-rolldown-vite:
+  test-e2e-vite-8:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
       - run: pnpm playwright install --with-deps
       - name: update overrides to use rolldown-vite and re-install
         run: |
-          jq '.pnpm.overrides.vite = "npm:rolldown-vite@^7.2.5"' package.json > package.tmp.json
+          jq '.pnpm.overrides.vite = "8.0.0-beta.7"' package.json > package.tmp.json
           mv package.tmp.json package.json
           pnpm i --no-frozen-lockfile
       - run: pnpm -r test:e2e


### PR DESCRIPTION
Follow up to https://github.com/davidmyersdev/vite-plugin-node-polyfills/pull/139

related: https://github.com/vitejs/rolldown-vite/issues/551
