### PR TITLE
fix: use oxc instead of esbuild when Rolldown is detected

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typecheck:vue": "pnpm -C ./examples/vue run typecheck"
   },
   "peerDependencies": {
-    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "dependencies": {
     "@rollup/plugin-inject": "^5.0.5",

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,10 +239,11 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
               : {},
           },
         },
-        esbuild: {
-          // In dev, the global polyfills need to be injected as a banner in order for isolated scripts (such as Vue SFCs) to have access to them.
-          banner: isDev ? globalShimsBanner : undefined,
-        },
+        // Vite 8+ (Rolldown) replaces esbuild with oxc for JS transforms
+        ...(isRolldownVite
+          ? { oxc: { jsxInject: isDev ? globalShimsBanner : undefined } }
+          : { esbuild: { banner: isDev ? globalShimsBanner : undefined } }
+        ),
         optimizeDeps: {
           exclude: [
             ...globalShimPaths,


### PR DESCRIPTION
Fixes #142

Vite 8 dropped esbuild in favor of oxc for JS transforms. The plugin was still setting `esbuild.banner` unconditionally, which produces this warning:

```
`esbuild` option was specified by "vite-plugin-node-polyfills" plugin.
This option is deprecated, please use `oxc` instead
```

The fix uses the existing `isRolldownVite` check to pick between `oxc.jsxInject` and `esbuild.banner` for dev banner injection, same pattern already used for `optimizeDeps.rolldownOptions` vs `esbuildOptions`.

```diff
-        esbuild: {
-          banner: isDev ? globalShimsBanner : undefined,
-        },
+        ...(isRolldownVite
+          ? { oxc: { jsxInject: isDev ? globalShimsBanner : undefined } }
+          : { esbuild: { banner: isDev ? globalShimsBanner : undefined } }
+        ),
```

Also adds `^8.0.0` to peerDependencies.