### PR TITLE
feat: add Vite 8 to peer deps range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
       - run: pnpm build:core
       - run: pnpm build:shims
       - run: pnpm playwright install --with-deps
-      - name: update overrides to use vite 8 beta and re-install
+      - name: update overrides to use vite 8 and re-install
         run: |
-          jq '.pnpm.overrides.vite = "8.0.0-beta.7"' package.json > package.tmp.json
+          jq '.pnpm.overrides.vite = "8.0.1"' package.json > package.tmp.json
           mv package.tmp.json package.json
           pnpm i --no-frozen-lockfile
       - run: pnpm -r test:e2e

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typecheck:vue": "pnpm -C ./examples/vue run typecheck"
   },
   "peerDependencies": {
-    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "dependencies": {
     "@rollup/plugin-inject": "^5.0.5",


### PR DESCRIPTION
Alternative to #149 as I don't think the fix is correct. This PR only adds Vite 8 to the peer deps range.
The warning will still be there, but this should be easier to merge than #149.

close #150
