### PR TITLE
fix: use oxc instead of esbuild when Rolldown is detected

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -239,10 +239,11 @@ export const nodePolyfills = (options: PolyfillOptions = {}): Plugin => {
               : {},
           },
         },
-        esbuild: {
-          // In dev, the global polyfills need to be injected as a banner in order for isolated scripts (such as Vue SFCs) to have access to them.
-          banner: isDev ? globalShimsBanner : undefined,
-        },
+        // Vite 8+ (Rolldown) replaces esbuild with oxc for JS transforms
+        ...(isRolldownVite
+          ? { oxc: { jsxInject: isDev ? globalShimsBanner : undefined } }
+          : { esbuild: { banner: isDev ? globalShimsBanner : undefined } }
+        ),
         optimizeDeps: {
           exclude: [
             ...globalShimPaths,


### PR DESCRIPTION
## Summary
- cherry-picks MetaNames/vite-plugin-node-polyfills@d1c6a2af49be3dd3a328d386d25ce140ec3487af
- applies the fix discussed in #142

## Context
Issue #142 references this exact commit by @yeboster, and this PR ports it into the upstream repository.