### PR TITLE
Conditionally polyfill globals

### DIFF
--- a/shims/buffer/index.ts
+++ b/shims/buffer/index.ts
@@ -1,7 +1,7 @@
 import {
   Blob,
   BlobOptions,
-  Buffer,
+  Buffer as PolyfillBuffer,
   File,
   FileOptions,
   INSPECT_MAX_BYTES,
@@ -19,6 +19,9 @@ import {
   transcode,
 // eslint-disable-next-line unicorn/prefer-node-protocol
 } from 'buffer'
+
+// Prefer the host's real `globalThis.Buffer` when present
+const Buffer = (typeof globalThis !== 'undefined' && (globalThis as { Buffer?: typeof PolyfillBuffer }).Buffer) || PolyfillBuffer
 
 export {
   Blob,

--- a/shims/global/index.ts
+++ b/shims/global/index.ts
@@ -1,5 +1,8 @@
 // eslint-disable-next-line @typescript-eslint/no-invalid-this
-const global = globalThis || this || self
+const polyfillGlobal = globalThis || this || self
+
+// Prefer the host's real `globalThis.global` when present
+const global = (typeof globalThis !== 'undefined' && (globalThis as { global?: typeof polyfillGlobal }).global) || polyfillGlobal
 
 export { global }
 export default global

--- a/shims/process/index.ts
+++ b/shims/process/index.ts
@@ -2,7 +2,10 @@
 // conflict with `node-stdlib-browser` which fails to import `process/browser.js`.
 // https://github.com/yarnpkg/yarn/issues/6907
 // eslint-disable-next-line unicorn/prefer-node-protocol
-import process from 'process'
+import polyfillProcess from 'process'
+
+// Prefer the host's real `globalThis.process` when present
+const process = (typeof globalThis !== 'undefined' && (globalThis as { process?: typeof polyfillProcess }).process) || polyfillProcess
 
 export { process }
 export default process

--- a/test/integration/global-references/index.test.ts
+++ b/test/integration/global-references/index.test.ts
@@ -28,6 +28,24 @@ describe('import globals', () => {
         Buffer.from("test");
       `))
     })
+
+    it('resolves to host globalThis.Buffer at runtime', async () => {
+      const { default: shimBuffer } = await import('vite-plugin-node-polyfills/shims/buffer')
+
+      expect(shimBuffer).toBe((globalThis as { Buffer?: typeof Buffer }).Buffer)
+    })
+
+    it('mutations to globalThis.Buffer are observed by the shim', async () => {
+      const { default: shimBuffer } = await import('vite-plugin-node-polyfills/shims/buffer') as { default: Record<string, unknown> }
+      const key = `__soft_fallback_test_${Date.now()}__`
+
+      try {
+        ;(globalThis as Record<string, Record<string, unknown>>).Buffer[key] = 'set-on-host'
+        expect(shimBuffer[key]).toEqual('set-on-host')
+      } finally {
+        delete (globalThis as Record<string, Record<string, unknown>>).Buffer[key]
+      }
+    })
   })
 
   describe('global', () => {
@@ -56,6 +74,24 @@ describe('import globals', () => {
         console.log(global);
       `))
     })
+
+    it('resolves to host globalThis.global at runtime', async () => {
+      const { default: shimGlobal } = await import('vite-plugin-node-polyfills/shims/global')
+
+      expect(shimGlobal).toBe((globalThis as { global?: typeof globalThis }).global)
+    })
+
+    it('mutations to globalThis.global are observed by the shim', async () => {
+      const { default: shimGlobal } = await import('vite-plugin-node-polyfills/shims/global') as { default: Record<string, unknown> }
+      const key = `__soft_fallback_test_${Date.now()}__`
+
+      try {
+        ;(globalThis as Record<string, Record<string, unknown>>).global[key] = 'set-on-host'
+        expect(shimGlobal[key]).toEqual('set-on-host')
+      } finally {
+        delete (globalThis as Record<string, Record<string, unknown>>).global[key]
+      }
+    })
   })
 
   describe('process', () => {
@@ -83,6 +119,24 @@ describe('import globals', () => {
 
         console.log(process);
       `))
+    })
+
+    it('resolves to host globalThis.process at runtime', async () => {
+      const { default: shimProcess } = await import('vite-plugin-node-polyfills/shims/process')
+
+      expect(shimProcess).toBe(globalThis.process)
+    })
+
+    it('mutations to globalThis.process are observed by the shim', async () => {
+      const { default: shimProcess } = await import('vite-plugin-node-polyfills/shims/process') as { default: Record<string, unknown> }
+      const key = `__soft_fallback_test_${Date.now()}__`
+
+      try {
+        ;(globalThis.process as Record<string, unknown>)[key] = 'set-on-host'
+        expect(shimProcess[key]).toEqual('set-on-host')
+      } finally {
+        delete (globalThis.process as Record<string, unknown>)[key]
+      }
     })
   })
 })


### PR DESCRIPTION
In 0.27.0+, polyfills were _always_ applied to globals. This breaks Vitest environments where an actual Node process is present. This change adds conditionals checks to the shims, only applying the polyfills when `globalThis` is missing.

> I'll admit I don't have full understanding of the codebase, but gave it a shot with the help of Claude. Hope this at least steers the maintainers towards a proper fix.

Fixes #159 